### PR TITLE
fix: add diff-match-patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "test": "node ./out/test/runTest.js"
   },
   "devDependencies": {
+    "@types/diff-match-patch": "^1.0.36",
     "@types/mocha": "^10.0.3",
     "@types/node": "18.x",
     "@types/vscode": "^1.82.0",
@@ -136,6 +137,7 @@
   },
   "dependencies": {
     "contentful-management": "^11.4.0",
+    "diff-match-patch": "^1.0.5",
     "yaml": "^2.3.3"
   }
 }


### PR DESCRIPTION
`npm install` 後に `npm run compile ` をしたら 以下のように util.jsで diff-match-patch が見つからないとエラーが出ました。

```
./src/util.ts 2:39-57
[tsl] ERROR in src\util.ts(2,40)
      TS2307: Cannot find module 'diff-match-patch' or its corresponding type declarations.
```

対応として `package.json` に diff-match-patch と その型を追加しました。
再度 `npm install` し、`npm run compile` をして成功することを確認しました。

`package-lock.json` の差分は出なかったので `package.json` への追加し忘れだと思います。
